### PR TITLE
Merge latest Library.Template

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,7 +15,7 @@
       ]
     },
     "dotnet-coverage": {
-      "version": "17.8.7",
+      "version": "17.8.6",
       "commands": [
         "dotnet-coverage"
       ]

--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "powershell": {
-      "version": "7.3.5",
+      "version": "7.3.7",
       "commands": [
         "pwsh"
       ]
@@ -15,7 +15,7 @@
       ]
     },
     "dotnet-coverage": {
-      "version": "17.7.3",
+      "version": "17.8.7",
       "commands": [
         "dotnet-coverage"
       ]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,6 @@ updates:
   schedule:
     interval: weekly
   ignore:
-    # This package has unlisted versions on nuget.org that are not supported. Avoid them.
-    - dependency-name: dotnet-format
-      versions: ["6.x", "7.x", "8.x"]
+  # This package has unlisted versions on nuget.org that are not supported. Avoid them.
+  - dependency-name: dotnet-format
+    versions: ["6.x", "7.x", "8.x"]

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <BaseIntermediateOutputPath>$(RepoRootPath)obj\$([MSBuild]::MakeRelative($(RepoRootPath), $(MSBuildProjectDirectory)))\</BaseIntermediateOutputPath>
     <BaseOutputPath Condition=" '$(BaseOutputPath)' == '' ">$(RepoRootPath)bin\$(MSBuildProjectName)\</BaseOutputPath>
     <PackageOutputPath>$(RepoRootPath)bin\Packages\$(Configuration)\</PackageOutputPath>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>11</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <AnalysisLevel>latest</AnalysisLevel>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,12 +6,12 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageVersion Include="QRCoder" Version="1.4.3" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageVersion Include="System.Drawing.Common" Version="7.0.0" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.0" />
-    <PackageVersion Include="xunit" Version="2.5.0" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageVersion Include="xunit" Version="2.5.1" />
     <PackageVersion Include="ZXing.Net" Version="0.16.9" />
     <PackageVersion Include="ZXing.Net.Bindings.Windows.Compatibility" Version="0.16.12" />
   </ItemGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
-  <!-- Include and reference README in nuge package, if a README is in the project directory. -->
+  <!-- Include and reference README in nuget package, if a README is in the project directory. -->
   <PropertyGroup>
     <PackageReadmeFile Condition="Exists('README.md')">README.md</PackageReadmeFile>
   </PropertyGroup>

--- a/src/Nerdbank.QRCodes/README.md
+++ b/src/Nerdbank.QRCodes/README.md
@@ -1,0 +1,36 @@
+# Nerdbank.QRCodes
+
+## Features
+
+* Decode a QR code (using the excellent ZXing.Net library, Windows only) from a high quality render or a photo with a QR code somewhere in the image.
+* Encode data in a QR code (using the excellent QRCoder library) supporting several graphic formats (some Windows only) and even as ASCII art.
+
+## Usage
+
+### Create a QR code
+
+There are lots of options for customizing QR codes including style, image in the center, colors, and output image format.
+Following is a basic example.
+
+```cs
+using QRCoder;
+
+QREncoder encoder = new();
+QRCodeGenerator generator = new();
+QRCodeData data = generator.CreateQrCode("https://some.url", encoder.ECCLevel);
+encoder.Encode(data, "some.png", traceSource: null);
+```
+
+### Decode a QR code
+
+Decoding a QR code is very straightforward.
+
+```cs
+using Bitmap bitmap = (Bitmap)Image.FromFile("some.jpg");
+if (QRDecoder.TryDecode(bitmap, out string? data))
+{
+	Console.WriteLine(data);
+}
+```
+
+Today this requires running on Windows.


### PR DESCRIPTION
- Bump powershell from 7.3.5 to 7.3.6 (#212)
- Bump dotnet-coverage from 17.7.3 to 17.8.0 (#211)
- Bump dotnet-coverage to 17.8.2
- Bump Microsoft.NET.Test.Sdk from 17.6.3 to 17.7.0 (#213)
- Bump Microsoft.NET.Test.Sdk from 17.7.0 to 17.7.1 (#214)
- Bump dotnet-coverage from 17.8.2 to 17.8.4 (#215)
- Align YAML indentation more consistently
- Bump Microsoft.NET.Test.Sdk from 17.7.1 to 17.7.2 (#218)
- Fix typo in comment
- Bump dotnet-coverage to 17.8.6
- Bump xunit from 2.5.0 to 2.5.1 (#219)
- Bump xunit.runner.visualstudio from 2.5.0 to 2.5.1 (#220)
- Bump powershell to 7.3.7
- Fix LangVersion at 11
- Bump dotnet-coverage to 17.8.7
- Add README for package
