### PR TITLE
Merge latest Library.Template

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,25 +3,19 @@
   "isRoot": true,
   "tools": {
     "powershell": {
-      "version": "7.3.7",
+      "version": "7.4.3",
       "commands": [
         "pwsh"
       ]
     },
-    "dotnet-format": {
-      "version": "5.1.250801",
-      "commands": [
-        "dotnet-format"
-      ]
-    },
     "dotnet-coverage": {
-      "version": "17.8.6",
+      "version": "17.11.3",
       "commands": [
         "dotnet-coverage"
       ]
     },
     "nbgv": {
-      "version": "3.6.133",
+      "version": "3.6.139",
       "commands": [
         "nbgv"
       ]

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # Refer to https://hub.docker.com/_/microsoft-dotnet-sdk for available versions
-FROM mcr.microsoft.com/dotnet/sdk:7.0.302-jammy
+FROM mcr.microsoft.com/dotnet/sdk:8.0.300-jammy
 
 # Installing mono makes `dotnet test` work without errors even for net472.
 # But installing it takes a long time, so it's excluded by default.

--- a/.editorconfig
+++ b/.editorconfig
@@ -27,6 +27,7 @@ indent_size = 2
 # Xml config files
 [*.{ruleset,config,nuspec,resx,vsixmanifest,vsct,runsettings}]
 indent_size = 2
+indent_style = space
 
 # JSON files
 [*.json]
@@ -41,6 +42,7 @@ indent_size = 4
 [*.{cs,vb}]
 # Sort using and Import directives with System.* appearing first
 dotnet_sort_system_directives_first = true
+dotnet_separate_import_directive_groups = false
 dotnet_style_qualification_for_field = true:warning
 dotnet_style_qualification_for_property = true:warning
 dotnet_style_qualification_for_method = true:warning

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,3 @@ updates:
   directory: /
   schedule:
     interval: weekly
-  ignore:
-  # This package has unlisted versions on nuget.org that are not supported. Avoid them.
-  - dependency-name: dotnet-format
-    versions: ["6.x", "7.x", "8.x"]

--- a/.gitignore
+++ b/.gitignore
@@ -352,3 +352,6 @@ MigrationBackup/
 
 # mac-created file to track user view preferences for a directory
 .DS_Store
+
+# Analysis results
+*.sarif

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -7,6 +7,7 @@
     "ms-dotnettools.csharp",
     "k--kato.docomment",
     "editorconfig.editorconfig",
+    "esbenp.prettier-vscode",
     "pflannery.vscode-versionlens",
     "davidanson.vscode-markdownlint",
     "dotjoshjohnson.xml",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,19 @@
   "omnisharp.enableEditorConfigSupport": true,
   "omnisharp.enableRoslynAnalyzers": true,
   "dotnet.completion.showCompletionItemsFromUnimportedNamespaces": true,
-  "dotnet.defaultSolution": "Nerdbank.QRCodes.sln"
+  "editor.formatOnSave": true,
+  "[xml]": {
+    "editor.wordWrap": "off"
+  },
+  // Treat these files as Azure Pipelines files
+  "files.associations": {
+    "**/azure-pipelines/**/*.yml": "azure-pipelines",
+    "azure-pipelines.yml": "azure-pipelines"
+  },
+  // Use Prettier as the default formatter for Azure Pipelines files.
+  // Needs to be explicitly configured: https://github.com/Microsoft/azure-pipelines-vscode#document-formatting
+  "[azure-pipelines]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": false // enable this when they conform
+  },
 }

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -5,7 +6,6 @@
     <BaseIntermediateOutputPath>$(RepoRootPath)obj\$([MSBuild]::MakeRelative($(RepoRootPath), $(MSBuildProjectDirectory)))\</BaseIntermediateOutputPath>
     <BaseOutputPath Condition=" '$(BaseOutputPath)' == '' ">$(RepoRootPath)bin\$(MSBuildProjectName)\</BaseOutputPath>
     <PackageOutputPath>$(RepoRootPath)bin\Packages\$(Configuration)\</PackageOutputPath>
-    <LangVersion>11</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <AnalysisLevel>latest</AnalysisLevel>
@@ -54,23 +54,4 @@
       <PackageReleaseNotes Condition="'$(PackageProjectUrl)'!=''">$(PackageProjectUrl)/releases/tag/v$(Version)</PackageReleaseNotes>
     </PropertyGroup>
   </Target>
-
-  <PropertyGroup Condition="'$(IsWpfTempProject)' == ''">
-    <IsWpfTempProject>false</IsWpfTempProject>
-    <IsWpfTempProject Condition="$(MSBuildProjectName.EndsWith('_wpftmp'))">true</IsWpfTempProject>
-  </PropertyGroup>
-
-  <!--
-    Inspired by https://github.com/dotnet/arcade/blob/cbfa29d4e859622ada3d226f90f103f659665d31/src/Microsoft.DotNet.Arcade.Sdk/tools/Workarounds.props#L14-L31
-
-    Disable Source Link and Xliff in WPF temp projects to avoid generating non-deterministic file names to obj dir.
-    The project name is non-deterministic and is included in the Source Link json file name and xlf directory names.
-    It's also not necessary to generate these assets.
-  -->
-  <PropertyGroup Condition="'$(IsWpfTempProject)' == 'true'">
-    <EnableSourceLink>false</EnableSourceLink>
-    <EmbedUntrackedSources>false</EmbedUntrackedSources>
-    <DeterministicSourcePaths>false</DeterministicSourcePaths>
-    <EnableXlfLocalization>false</EnableXlfLocalization>
-  </PropertyGroup>
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,9 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
-    <!-- Workaround https://github.com/dotnet/wpf/issues/1718 -->
-    <EmbedUntrackedSources Condition=" '$(UseWPF)' == 'true' ">false</EmbedUntrackedSources>
+    <LangVersion Condition="'$(Language)'=='C#'">12</LangVersion>
+    <LangVersion Condition="'$(Language)'=='VB'">16.9</LangVersion>
   </PropertyGroup>
-
   <ItemGroup>
     <!-- Avoid compile error about missing namespace when combining ImplicitUsings with .NET Framework target frameworks. -->
     <Using Remove="System.Net.Http" Condition="'$(TargetFrameworkIdentifier)'=='.NETFramework'" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <!-- https://learn.microsoft.com/nuget/consume-packages/central-package-management -->
   <PropertyGroup>
@@ -6,23 +7,20 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageVersion Include="QRCoder" Version="1.4.3" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageVersion Include="System.Drawing.Common" Version="7.0.0" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.1" />
-    <PackageVersion Include="xunit" Version="2.5.1" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageVersion Include="xunit" Version="2.9.0" />
     <PackageVersion Include="ZXing.Net" Version="0.16.9" />
     <PackageVersion Include="ZXing.Net.Bindings.Windows.Compatibility" Version="0.16.12" />
   </ItemGroup>
   <ItemGroup>
-    <GlobalPackageReference Include="CSharpIsNullAnalyzer" Version="0.1.495" />
+    <GlobalPackageReference Include="CSharpIsNullAnalyzer" Version="0.1.593" />
     <GlobalPackageReference Include="DotNetAnalyzers.DocumentationAnalyzers" Version="1.0.0-beta.59" />
-    <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.6.133" />
+    <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.6.139" />
     <GlobalPackageReference Include="Nullable" Version="1.3.1" />
-    <GlobalPackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.507" />
-  </ItemGroup>
-  <ItemGroup>
-    <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
+    <GlobalPackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556" />
   </ItemGroup>
 </Project>

--- a/azure-pipelines/artifacts/_pipelines.ps1
+++ b/azure-pipelines/artifacts/_pipelines.ps1
@@ -7,7 +7,8 @@
 [CmdletBinding()]
 param (
     [string]$ArtifactNameSuffix,
-    [switch]$StageOnly
+    [switch]$StageOnly,
+    [switch]$AvoidSymbolicLinks
 )
 
 Function Set-PipelineVariable($name, $value) {
@@ -24,7 +25,7 @@ Function Test-ArtifactUploaded($artifactName) {
     Test-Path "env:$varName"
 }
 
-& "$PSScriptRoot/_stage_all.ps1" -ArtifactNameSuffix $ArtifactNameSuffix |% {
+& "$PSScriptRoot/_stage_all.ps1" -ArtifactNameSuffix $ArtifactNameSuffix -AvoidSymbolicLinks:$AvoidSymbolicLinks |% {
     # Set a variable which will out-live this script so that a subsequent attempt to collect and upload artifacts
     # will skip this one from a check in the _all.ps1 script.
     Set-PipelineVariable "ARTIFACTSTAGED_$($_.Name.ToUpper())" 'true'

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -4,6 +4,7 @@ parameters:
   default:
     vmImage: windows-2022
 - name: includeMacOS
+  type: boolean
 - name: RunTests
   type: boolean
   default: true
@@ -35,6 +36,8 @@ jobs:
   - template: dotnet.yml
     parameters:
       RunTests: ${{ parameters.RunTests }}
+  - script: dotnet format --verify-no-changes --no-restore
+    displayName: 💅 Verify formatted code
 
 - job: macOS
   condition: ${{ parameters.includeMacOS }}

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.302",
+    "version": "8.0.300",
     "rollForward": "patch",
     "allowPrerelease": false
   }

--- a/init.ps1
+++ b/init.ps1
@@ -84,8 +84,7 @@ try {
     $HeaderColor = 'Green'
 
     $RestoreArguments = @()
-    if ($Interactive)
-    {
+    if ($Interactive) {
         $RestoreArguments += '--interactive'
     }
 
@@ -98,10 +97,10 @@ try {
     }
 
     if (!$NoToolRestore -and $PSCmdlet.ShouldProcess("dotnet tool", "restore")) {
-      dotnet tool restore @RestoreArguments
-      if ($lastexitcode -ne 0) {
-          throw "Failure while restoring dotnet CLI tools."
-      }
+        dotnet tool restore @RestoreArguments
+        if ($lastexitcode -ne 0) {
+            throw "Failure while restoring dotnet CLI tools."
+        }
     }
 
     & "$PSScriptRoot/tools/Set-EnvVars.ps1" -Variables $EnvVars -PrependPath $PrependPath | Out-Null

--- a/settings.VisualStudio.json
+++ b/settings.VisualStudio.json
@@ -1,0 +1,3 @@
+{
+  "textEditor.codeCleanup.profile": "profile1"
+}

--- a/src/AssemblyInfo.vb
+++ b/src/AssemblyInfo.vb
@@ -1,0 +1,6 @@
+' Copyright (c) COMPANY-PLACEHOLDER. All rights reserved.
+' Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+Imports System.Runtime.InteropServices
+
+<Assembly: DefaultDllImportSearchPaths(DllImportSearchPath.SafeDirectories)>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <!-- Include and reference README in nuget package, if a README is in the project directory. -->
   <PropertyGroup>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,6 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <ItemGroup>
-    <Compile Include="$(MSBuildThisFileDirectory)AssemblyInfo.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)AssemblyInfo.cs" Condition=" '$(Language)'=='C#' " />
+    <Compile Include="$(MSBuildThisFileDirectory)AssemblyInfo.vb" Condition=" '$(Language)'=='VB' " />
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove($(MSBuildThisFile), $(MSBuildThisFileDirectory)..))" />

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <Import Project="$([MSBuild]::GetPathOfFileAbove($(MSBuildThisFile), $(MSBuildThisFileDirectory)..))" />
 

--- a/test/Directory.Build.targets
+++ b/test/Directory.Build.targets
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <Import Project="$([MSBuild]::GetPathOfFileAbove($(MSBuildThisFile), $(MSBuildThisFileDirectory)..))" />
 </Project>


### PR DESCRIPTION
- Bump .NET SDK to 7.0.401
- Bump xunit.runner.visualstudio from 2.5.1 to 2.5.3 (#224)
- Bump dotnet-coverage from 17.8.6 to 17.9.1 (#222)
- Bump powershell from 7.3.7 to 7.3.8 (#221)
- Bump xunit from 2.5.1 to 2.5.2 (#223)
- Bump xunit from 2.5.2 to 2.5.3 (#226)
- Bump dotnet-coverage from 17.9.1 to 17.9.3 (#225)
- Bump powershell from 7.3.8 to 7.3.9 (#227)
- Bump xunit from 2.5.3 to 2.6.1 (#228)
- Ignore `dotnet-format` v9 versions
- Bump Microsoft.NET.Test.Sdk from 17.7.2 to 17.8.0 (#229)
- Apply Directory.Packages.props in Apply-Template.ps1
- Bump to the .NET 8.0.100 SDK
- Bump xunit from 2.6.1 to 2.6.2 (#234)
- Bump Microsoft.SourceLink.GitHub from 1.1.1 to 8.0.0 (#232)
- Bump powershell from 7.3.9 to 7.4.0 (#231)
- Bump xunit.runner.visualstudio from 2.5.3 to 2.5.4 (#233)
- Validate formatted code in builds
- Enable auto-format on save in VS and VS Code
- Remove `dotnet-format` as a tool
- Make symbolic link failures more detectable
- Add xml header to msbuild files
- Stop VS Code from wrapping xml files
- Add dotnet_separate_import_directive_groups to .editorconfig
- Bump xunit from 2.6.2 to 2.6.3 (#239)
- Bump dotnet-coverage from 17.9.3 to 17.9.5 (#238)
- Bump xunit.runner.visualstudio from 2.5.4 to 2.5.5 (#237)
- Bump dotnet-coverage from 17.9.5 to 17.9.6 (#240)
- Bump xunit.runner.visualstudio from 2.5.5 to 2.5.6 (#243)
- Bump xunit from 2.6.3 to 2.6.4 (#242)
- Bump StyleCop.Analyzers.Unstable from 1.2.0.507 to 1.2.0.556 (#241)
- Bump powershell from 7.4.0 to 7.4.1 (#245)
- Bump xunit from 2.6.4 to 2.6.6
- Add switch to avoid creating symbolic links
- Clarify parameter type in AzP template
- Bump dotnet-coverage from 17.9.6 to 17.10.1Bumps [dotnet-coverage](https://github.com/microsoft/codecoverage) from 17.9.6 to 17.10.1.- [Commits](https://github.com/microsoft/codecoverage/commits)---updated-dependencies:- dependency-name: dotnet-coverage  dependency-type: direct:production  update-type: version-update:semver-minor...Signed-off-by: dependabot[bot] <support@github.com>
- Format init.ps1
- Bump dotnet-coverage from 17.10.1 to 17.10.2 (#250)
- Recommend prettier
- Identify AzP-related YAML files
- Bump Microsoft.NET.Test.Sdk from 17.8.0 to 17.9.0 (#251)
- Bump .NET SDK from 8.0.100 to 8.0.201
- Bump xunit.runner.visualstudio from 2.5.6 to 2.5.7 (#254)
- Bump dotnet-coverage from 17.10.2 to 17.10.3 (#252)
- Bump xunit from 2.6.6 to 2.7.0 (#253)
- fix typo
- Bump dotnet-coverage from 17.10.3 to 17.10.4 (#264)
- Bump dependencies
- Bump xunit to 2.8.0
- Use spaces for xml config files
- Bump .NET SDK to 8.0.300
- Merge test related dependency updates (#271)
- Bump dotnet-coverage from 17.11.0 to 17.11.3 (#272)
- Bump Nerdbank.GitVersioning to 3.6.139
- Bump nbgv to 3.6.139
- Drop SourceLink package reference
- Remove WPF workarounds for bugs fixed years ago
- Bump powershell from 7.4.2 to 7.4.3 (#275)
- Ignore .sarif files
- Add support for VB.NET projects
- Fix template expansion
- Bump several dependencies
