### PR TITLE
Build universal iOS framework

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -175,7 +175,7 @@ jobs:
     needs:
     - build
     - android
-    runs-on: ubuntu-20.04
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,11 @@ jobs:
         if: startsWith(matrix.os, 'ubuntu')
         working-directory: src/nerdbank-qrcodes
 
+      - name: 📱 Build iOS Framework
+        run: azure-pipelines/build_ios_framework.ps1
+        shell: pwsh
+        if: startsWith(matrix.os, 'macos')
+
       - name: 🛠 dotnet build
         run: |
           dotnet build -t:build -p:Platform=x64 --no-restore -c ${{ env.BUILDCONFIGURATION }} -warnaserror /bl:"${{ runner.temp }}/_artifacts/build_logs/build_x64.binlog"
@@ -126,6 +131,12 @@ jobs:
           name: rust-${{ runner.os }}
           path: ${{ runner.temp }}/_artifacts/rust
         if: always()
+      - name: 📢 Upload ios_framework
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios_framework
+          path: ${{ runner.temp }}/_artifacts/ios_framework
+        if: startsWith(matrix.os, 'macos')
       - name: 📢 Publish code coverage results to codecov.io
         run: ./azure-pipelines/publish-CodeCov.ps1 -CodeCovToken "${{ secrets.CODECOV_TOKEN }}" -PathToCodeCoverage "${{ runner.temp }}/_artifacts/coverageResults" -Name "${{ runner.os }} Coverage Results" -Flags "${{ runner.os }}Host,${{ env.BUILDCONFIGURATION }}"
         shell: pwsh
@@ -213,6 +224,12 @@ jobs:
         with:
           name: rust-macOS
           path: src/nerdbank-qrcodes/target
+
+      - name: 🔻 Download iOS framework
+        uses: actions/download-artifact@v4
+        with:
+          name: ios_framework
+          path: bin/release/nerdbank_qrcodes.framework
 
       - name: 🛠 dotnet pack
         run: dotnet pack --no-restore -c ${{ env.BUILDCONFIGURATION }} -warnaserror /bl:"${{ runner.temp }}/_artifacts/build_logs/build.binlog"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -229,7 +229,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ios_framework
-          path: bin/release/nerdbank_qrcodes.framework
+          path: bin/release/nerdbank_qrcodes.xcframework
 
       - name: 🛠 dotnet pack
         run: dotnet pack --no-restore -c ${{ env.BUILDCONFIGURATION }} -warnaserror /bl:"${{ runner.temp }}/_artifacts/build_logs/build.binlog"

--- a/azure-pipelines/Get-RustTargets.ps1
+++ b/azure-pipelines/Get-RustTargets.ps1
@@ -4,8 +4,9 @@ if ($IsLinux) {
 elseif ($IsMacOS) {
     ,'aarch64-apple-darwin'
     ,'x86_64-apple-darwin'
-    ,'aarch64-apple-ios'
-    ,'x86_64-apple-ios'
+    ,'aarch64-apple-ios'     # device
+    ,'x86_64-apple-ios'      # simulator
+    ,'aarch64-apple-ios-sim' # simulator
 }
 else { # Windows
     ,'aarch64-pc-windows-msvc'

--- a/azure-pipelines/Info.plist
+++ b/azure-pipelines/Info.plist
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>English</string>
+	<key>CFBundleExecutable</key>
+	<string>nerdbank_qrcodes</string>
+	<key>CFBundleIconFile</key>
+	<string></string>
+	<key>CFBundleIdentifier</key>
+	<string>net.nerdbank.qrcodes</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>$version$</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$version$</string>
+	<key>CSResourcesFileMapped</key>
+	<true/>
+	<key>MinimumOSVersion</key>
+	<string>12.1</string>
+</dict>
+</plist>

--- a/azure-pipelines/artifacts/ios_framework.ps1
+++ b/azure-pipelines/artifacts/ios_framework.ps1
@@ -1,0 +1,14 @@
+$RepoRoot = [System.IO.Path]::GetFullPath("$PSScriptRoot\..\..")
+$BuildConfiguration = $env:BUILDCONFIGURATION
+if (!$BuildConfiguration) {
+    $BuildConfiguration = 'Debug'
+}
+
+$BuildConfiguration = $BuildConfiguration.ToLower()
+$FrameworkRoot = "$RepoRoot/bin/$BuildConfiguration/nerdbank_qrcodes.framework"
+
+if (!(Test-Path $FrameworkRoot))  { return }
+
+@{
+    "$FrameworkRoot" = (Get-ChildItem $FrameworkRoot -Recurse)
+}

--- a/azure-pipelines/artifacts/ios_framework.ps1
+++ b/azure-pipelines/artifacts/ios_framework.ps1
@@ -5,7 +5,7 @@ if (!$BuildConfiguration) {
 }
 
 $BuildConfiguration = $BuildConfiguration.ToLower()
-$FrameworkRoot = "$RepoRoot/bin/$BuildConfiguration/nerdbank_qrcodes.framework"
+$FrameworkRoot = "$RepoRoot/bin/$BuildConfiguration/nerdbank_qrcodes.xcframework"
 
 if (!(Test-Path $FrameworkRoot))  { return }
 

--- a/azure-pipelines/build_ios_framework.ps1
+++ b/azure-pipelines/build_ios_framework.ps1
@@ -1,0 +1,46 @@
+[CmdletBinding()]
+param (
+    [parameter()]
+    [string]$Configuration = 'release'
+)
+
+$version = dotnet nbgv get-version -p $PSScriptRoot/../src/nerdbank-qrcodes -v SimpleVersion
+$plist = Get-Content $PSScriptRoot/Info.plist
+$plist = $plist.Replace('$version$', $version)
+$IntermediatePlistPath = "$PSScriptRoot/../obj/Info.plist"
+Set-Content -Path $IntermediatePlistPath -Value $plist -Encoding utf8NoBOM
+if ($IsMacOS) {
+    plutil -convert binary1 $IntermediatePlistPath
+    chmod +x $IntermediatePlistPath
+}
+else {
+    Write-Warning "Skipped plutil invocation because this is not macOS."
+}
+
+# copy Info.plist and the binary into the appropriate .framework directory structure
+# so that when NativeBindings.targets references it with ResolvedFileToPublish, it will be treated appropriately.
+$RustTargetBaseDir = Resolve-Path "$PSScriptRoot/../src/nerdbank-qrcodes/target"
+$RustDylibFileName = "libnerdbank_qrcodes.dylib"
+$Arm64RustOutput = "$RustTargetBaseDir/aarch64-apple-ios/$Configuration/$RustDylibFileName"
+$X64RustOutput = "$RustTargetBaseDir/x86_64-apple-ios/$Configuration/$RustDylibFileName"
+
+$FrameworkDir = "$PSScriptRoot/../bin/$Configuration/nerdbank_qrcodes.framework"
+New-Item -Path $FrameworkDir -ItemType Directory -Force | Out-Null
+$FrameworkDir = Resolve-Path $FrameworkDir
+
+Write-Host "Preparing Apple Framework at: $FrameworkDir" -ForegroundColor Cyan
+
+Copy-Item $IntermediatePlistPath "$FrameworkDir/Info.plist"
+Write-Host "Created Info.plist with version $version"
+
+if ($IsMacOS) {
+    # Create a universal binary that contains both arm64 and x64 architectures.
+    lipo -create -output $FrameworkDir/nerdbank_qrcodes $Arm64RustOutput $X64RustOutput
+    install_name_tool -id "@rpath/nerdbank_qrcodes.framework/nerdbank_qrcodes" "$FrameworkDir/nerdbank_qrcodes"
+    chmod +x "$FrameworkDir/nerdbank_qrcodes"
+}
+else {
+    Copy-Item $Arm64RustOutput "$FrameworkDir/nerdbank_qrcodes"
+    Write-Warning "Skipped critical steps because this is not macOS."
+}
+Write-Host "Copied nerdbank_qrcodes to framework"

--- a/azure-pipelines/manifest
+++ b/azure-pipelines/manifest
@@ -1,0 +1,12 @@
+﻿<BindingAssembly>
+	<NativeReference Name="nerdbank_qrcodes.xcframework">
+		<ForceLoad></ForceLoad>
+		<Frameworks></Frameworks>
+		<IsCxx></IsCxx>
+		<Kind>Framework</Kind>
+		<LinkerFlags></LinkerFlags>
+		<NeedsGccExceptionHandling></NeedsGccExceptionHandling>
+		<SmartLink></SmartLink>
+		<WeakFrameworks></WeakFrameworks>
+	</NativeReference>
+</BindingAssembly>

--- a/init.ps1
+++ b/init.ps1
@@ -105,6 +105,14 @@ try {
         $RestoreArguments += '--interactive'
     }
 
+    if (!$NoRestore -and $PSCmdlet.ShouldProcess(".NET workloads", "Restore")) {
+        Write-Host "Restoring applicable .NET workloads" -ForegroundColor $HeaderColor
+        dotnet workload restore
+        if ($lastexitcode -ne 0) {
+            throw "Failure while restoring workloads."
+        }
+    }
+
     if (!$NoRestore -and $PSCmdlet.ShouldProcess("NuGet packages", "Restore")) {
         Write-Host "Restoring NuGet packages" -ForegroundColor $HeaderColor
         dotnet restore @RestoreArguments -p:Platform=x64

--- a/src/Nerdbank.QRCodes/NativeBindings.targets
+++ b/src/Nerdbank.QRCodes/NativeBindings.targets
@@ -69,7 +69,11 @@
 
     <!-- iOS -->
     <MobileRustBinary Condition="'$(Platform)'=='AnyCPU' or ('$(Platform)'=='arm64' and $([MSBuild]::IsOsPlatform('OSX')))" Include="$(iOSFrameworkPath)/**">
-      <PackagePath>runtimes/ios-universal/native/$(iOSFrameworkName)/</PackagePath>
+      <PackagePath>lib/net8.0-ios17.0/Nerdbank.QRCodes.resources/$(iOSFrameworkName)/</PackagePath>
+      <TargetOS>iOS</TargetOS>
+    </MobileRustBinary>
+    <MobileRustBinary Condition="'$(Platform)'=='AnyCPU' or ('$(Platform)'=='arm64' and $([MSBuild]::IsOsPlatform('OSX')))" Include="$(RepoRootPath)/azure-pipelines/manifest">
+      <PackagePath>lib/net8.0-ios17.0/Nerdbank.QRCodes.resources/</PackagePath>
       <TargetOS>iOS</TargetOS>
     </MobileRustBinary>
   </ItemGroup>

--- a/src/Nerdbank.QRCodes/NativeBindings.targets
+++ b/src/Nerdbank.QRCodes/NativeBindings.targets
@@ -7,8 +7,8 @@
     <RustOutputAndroidArm64>$(RustOutputDirBase)aarch64-linux-android/$(RustConfiguration)/libnerdbank_qrcodes.so</RustOutputAndroidArm64>
     <RustOutputAndroidX64>$(RustOutputDirBase)x86_64-linux-android/$(RustConfiguration)/libnerdbank_qrcodes.so</RustOutputAndroidX64>
 
-    <RustOutputiOSArm64>$(RustOutputDirBase)aarch64-apple-ios/$(RustConfiguration)/libnerdbank_qrcodes.dylib</RustOutputiOSArm64>
-    <RustOutputiOSX64>$(RustOutputDirBase)x86_64-apple-ios/$(RustConfiguration)/libnerdbank_qrcodes.dylib</RustOutputiOSX64>
+    <iOSFrameworkName>nerdbank_qrcodes.framework</iOSFrameworkName>
+    <iOSFrameworkPath>$(RepoRootPath)bin/$(RustConfiguration)/$(iOSFrameworkName)</iOSFrameworkPath>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <MobileRustBinary>
@@ -68,12 +68,8 @@
     </DesktopRustBinary>
 
     <!-- iOS -->
-    <MobileRustBinary Condition="'$(Platform)'=='AnyCPU' or ('$(Platform)'=='arm64' and $([MSBuild]::IsOsPlatform('OSX')))" Include="$(RustOutputiOSArm64)">
-      <PackagePath>runtimes/ios-arm64/native/</PackagePath>
-      <TargetOS>iOS</TargetOS>
-    </MobileRustBinary>
-    <MobileRustBinary Condition="'$(Platform)'=='AnyCPU' or ('$(Platform)'=='x64' and $([MSBuild]::IsOsPlatform('OSX')))" Include="$(RustOutputiOSX64)">
-      <PackagePath>runtimes/ios-x64/native/</PackagePath>
+    <MobileRustBinary Condition="'$(Platform)'=='AnyCPU' or ('$(Platform)'=='arm64' and $([MSBuild]::IsOsPlatform('OSX')))" Include="$(iOSFrameworkPath)/*">
+      <PackagePath>runtimes/ios-universal/native/$(iOSFrameworkName)/</PackagePath>
       <TargetOS>iOS</TargetOS>
     </MobileRustBinary>
   </ItemGroup>

--- a/src/Nerdbank.QRCodes/NativeBindings.targets
+++ b/src/Nerdbank.QRCodes/NativeBindings.targets
@@ -7,7 +7,7 @@
     <RustOutputAndroidArm64>$(RustOutputDirBase)aarch64-linux-android/$(RustConfiguration)/libnerdbank_qrcodes.so</RustOutputAndroidArm64>
     <RustOutputAndroidX64>$(RustOutputDirBase)x86_64-linux-android/$(RustConfiguration)/libnerdbank_qrcodes.so</RustOutputAndroidX64>
 
-    <iOSFrameworkName>nerdbank_qrcodes.framework</iOSFrameworkName>
+    <iOSFrameworkName>nerdbank_qrcodes.xcframework</iOSFrameworkName>
     <iOSFrameworkPath>$(RepoRootPath)bin/$(RustConfiguration)/$(iOSFrameworkName)</iOSFrameworkPath>
   </PropertyGroup>
   <ItemDefinitionGroup>
@@ -68,7 +68,7 @@
     </DesktopRustBinary>
 
     <!-- iOS -->
-    <MobileRustBinary Condition="'$(Platform)'=='AnyCPU' or ('$(Platform)'=='arm64' and $([MSBuild]::IsOsPlatform('OSX')))" Include="$(iOSFrameworkPath)/*">
+    <MobileRustBinary Condition="'$(Platform)'=='AnyCPU' or ('$(Platform)'=='arm64' and $([MSBuild]::IsOsPlatform('OSX')))" Include="$(iOSFrameworkPath)/**">
       <PackagePath>runtimes/ios-universal/native/$(iOSFrameworkName)/</PackagePath>
       <TargetOS>iOS</TargetOS>
     </MobileRustBinary>

--- a/src/Nerdbank.QRCodes/NativeMethods.cs
+++ b/src/Nerdbank.QRCodes/NativeMethods.cs
@@ -10,7 +10,12 @@ namespace Nerdbank.QRCodes;
 /// </summary>
 internal static unsafe class NativeMethods
 {
+#if IOS
+	// https://github.com/xamarin/xamarin-macios/issues/21238
+	private const string LibraryName = "@rpath/nerdbank_qrcodes.framework/nerdbank_qrcodes";
+#else
 	private const string LibraryName = "nerdbank_qrcodes";
+#endif
 
 	/// <summary>
 	/// Decodes a QR code from an image saved to a file.

--- a/src/Nerdbank.QRCodes/Nerdbank.QRCodes.csproj
+++ b/src/Nerdbank.QRCodes/Nerdbank.QRCodes.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0;net8.0-windows</TargetFrameworks>
+    <TargetFrameworks Condition="!$([MSBuild]::IsOsPlatform('Linux'))">$(TargetFrameworks);net8.0-ios17.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Description>Provides QR code encoding and decoding functions.</Description>
   </PropertyGroup>

--- a/src/Nerdbank.QRCodes/net8.0-ios17.0/PublicAPI.Shipped.txt
+++ b/src/Nerdbank.QRCodes/net8.0-ios17.0/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Nerdbank.QRCodes/net8.0-ios17.0/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.QRCodes/net8.0-ios17.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,28 @@
+Nerdbank.QRCodes.QRDecoder
+Nerdbank.QRCodes.QREncoder
+Nerdbank.QRCodes.QREncoder.BackgroundColor.get -> System.Drawing.Color
+Nerdbank.QRCodes.QREncoder.BackgroundColor.set -> void
+Nerdbank.QRCodes.QREncoder.DarkColor.get -> System.Drawing.Color
+Nerdbank.QRCodes.QREncoder.DarkColor.set -> void
+Nerdbank.QRCodes.QREncoder.ECCLevel.get -> QRCoder.QRCodeGenerator.ECCLevel
+Nerdbank.QRCodes.QREncoder.ECCLevel.set -> void
+Nerdbank.QRCodes.QREncoder.Encode(QRCoder.QRCodeData! data, string! fileFormatExtension, System.Diagnostics.TraceSource? traceSource) -> byte[]!
+Nerdbank.QRCodes.QREncoder.Encode(QRCoder.QRCodeData! data, System.IO.FileInfo! outputFile, System.Diagnostics.TraceSource? traceSource) -> void
+Nerdbank.QRCodes.QREncoder.QREncoder() -> void
+Nerdbank.QRCodes.QREncoder.IconBackgroundColor.get -> System.Drawing.Color?
+Nerdbank.QRCodes.QREncoder.IconBackgroundColor.set -> void
+Nerdbank.QRCodes.QREncoder.IconBorderWidth.get -> int
+Nerdbank.QRCodes.QREncoder.IconBorderWidth.set -> void
+Nerdbank.QRCodes.QREncoder.IconPath.get -> System.IO.FileInfo?
+Nerdbank.QRCodes.QREncoder.IconPath.set -> void
+Nerdbank.QRCodes.QREncoder.IconSizePercent.get -> int
+Nerdbank.QRCodes.QREncoder.IconSizePercent.set -> void
+Nerdbank.QRCodes.QREncoder.LightColor.get -> System.Drawing.Color
+Nerdbank.QRCodes.QREncoder.LightColor.set -> void
+Nerdbank.QRCodes.QREncoder.ModuleSize.get -> int
+Nerdbank.QRCodes.QREncoder.ModuleSize.set -> void
+Nerdbank.QRCodes.QREncoder.NoPadding.get -> bool
+Nerdbank.QRCodes.QREncoder.NoPadding.set -> void
+static Nerdbank.QRCodes.QRDecoder.TryDecode(System.ReadOnlySpan<byte> image, out string? data) -> bool
+static Nerdbank.QRCodes.QRDecoder.TryDecode(System.ReadOnlySpan<char> imagePath, out string? data) -> bool
+static Nerdbank.QRCodes.QREncoder.SupportedExtensions.get -> System.Collections.Generic.IReadOnlySet<string!>!


### PR DESCRIPTION
Most importantly, this exposes the native library as a "framework" in iOS so that a consuming iOS application will not be rejected by the App Store. 

In addition to this though, we combine both x64 and arm64 *simulator* binaries into one *universal* binary, which should help make things "just work" whether the simulator runs on an x64 or an arm64 (Apple Silicone) mac.