### PR TITLE
Merge latest Library.Template

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,19 +3,19 @@
   "isRoot": true,
   "tools": {
     "powershell": {
-      "version": "7.4.3",
+      "version": "7.4.5",
       "commands": [
         "pwsh"
       ]
     },
     "dotnet-coverage": {
-      "version": "17.11.3",
+      "version": "17.12.4",
       "commands": [
         "dotnet-coverage"
       ]
     },
     "nbgv": {
-      "version": "3.6.139",
+      "version": "3.6.143",
       "commands": [
         "nbgv"
       ]

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # Refer to https://hub.docker.com/_/microsoft-dotnet-sdk for available versions
-FROM mcr.microsoft.com/dotnet/sdk:8.0.300-jammy
+FROM mcr.microsoft.com/dotnet/sdk:8.0.400-jammy
 
 # Installing mono makes `dotnet test` work without errors even for net472.
 # But installing it takes a long time, so it's excluded by default.

--- a/.editorconfig
+++ b/.editorconfig
@@ -186,5 +186,8 @@ dotnet_diagnostic.DOC202.severity = warning
 # CA1062: Validate arguments of public methods
 dotnet_diagnostic.CA1062.severity = warning
 
+# CA2016: Forward the CancellationToken parameter
+dotnet_diagnostic.CA2016.severity = warning
+
 [*.sln]
 indent_style = tab

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,122 +27,122 @@ jobs:
           - windows-latest
 
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
-      - name: ⚙ Install prerequisites
-        run: |
-          ./init.ps1 -UpgradePrerequisites
-          dotnet --info
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
+    - name: ⚙ Install prerequisites
+      run: |
+        ./init.ps1 -UpgradePrerequisites
+        dotnet --info
 
-          # Print mono version if it is present.
-          if (Get-Command mono -ErrorAction SilentlyContinue) {
-            mono --version
-          }
-        shell: pwsh
-      - name: ⚙️ Set pipeline variables based on source
-        run: azure-pipelines/variables/_pipelines.ps1
-        shell: pwsh
-      - name: 🛠️ cargo build
-        run: src/nerdbank-qrcodes/build_all.ps1 -Release
-        shell: pwsh
+        # Print mono version if it is present.
+        if (Get-Command mono -ErrorAction SilentlyContinue) {
+          mono --version
+        }
+      shell: pwsh
+    - name: ⚙️ Set pipeline variables based on source
+      run: azure-pipelines/variables/_pipelines.ps1
+      shell: pwsh
+    - name: 🛠️ cargo build
+      run: src/nerdbank-qrcodes/build_all.ps1 -Release
+      shell: pwsh
 
-      - uses: taiki-e/install-action@v2
-        with:
-          tool: cross
-        if: startsWith(matrix.os, 'ubuntu')
-        name: ⚙️ cargo install cross
+    - uses: taiki-e/install-action@v2
+      with:
+        tool: cross
+      if: startsWith(matrix.os, 'ubuntu')
+      name: ⚙️ cargo install cross
 
-      - name: 🛠️ cross build linux-arm64
-        run: cross build -r --target=aarch64-unknown-linux-gnu
-        shell: pwsh
-        if: startsWith(matrix.os, 'ubuntu')
-        working-directory: src/nerdbank-qrcodes
+    - name: 🛠️ cross build linux-arm64
+      run: cross build -r --target=aarch64-unknown-linux-gnu
+      shell: pwsh
+      if: startsWith(matrix.os, 'ubuntu')
+      working-directory: src/nerdbank-qrcodes
 
-      - name: 📱 Build iOS Framework
-        run: azure-pipelines/build_ios_framework.ps1
-        shell: pwsh
-        if: startsWith(matrix.os, 'macos')
+    - name: 📱 Build iOS Framework
+      run: azure-pipelines/build_ios_framework.ps1
+      shell: pwsh
+      if: startsWith(matrix.os, 'macos')
 
-      - name: 🛠 dotnet build
-        run: |
-          dotnet build -t:build -p:Platform=x64 --no-restore -c ${{ env.BUILDCONFIGURATION }} -warnaserror /bl:"${{ runner.temp }}/_artifacts/build_logs/build_x64.binlog"
-          dotnet build -t:build -p:Platform=ARM64 --no-restore -c ${{ env.BUILDCONFIGURATION }} -warnaserror /bl:"${{ runner.temp }}/_artifacts/build_logs/build_arm64.binlog"
-      - name: 🧪 dotnet test
-        run: azure-pipelines/dotnet-test-cloud.ps1 -Configuration ${{ env.BUILDCONFIGURATION }} -Agent ${{ runner.os }}
-        shell: pwsh
-      - name: ⚙ Update pipeline variables based on build outputs
-        run: azure-pipelines/variables/_pipelines.ps1
-        shell: pwsh
-      - name: 📥 Collect artifacts
-        run: azure-pipelines/artifacts/_stage_all.ps1
-        shell: pwsh
-        if: always()
-      - name: 📢 Upload project.assets.json files
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: projectAssetsJson-${{ runner.os }}
-          path: ${{ runner.temp }}/_artifacts/projectAssetsJson
-        continue-on-error: true
-      - name: 📢 Upload variables
-        uses: actions/upload-artifact@v4
-        with:
-          name: variables-${{ runner.os }}
-          path: ${{ runner.temp }}/_artifacts/Variables
-        continue-on-error: true
-      - name: 📢 Upload build_logs
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: build_logs-${{ runner.os }}
-          path: ${{ runner.temp }}/_artifacts/build_logs
-        continue-on-error: true
-      - name: 📢 Upload test_logs
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: test_logs-${{ runner.os }}
-          path: ${{ runner.temp }}/_artifacts/test_logs
-        continue-on-error: true
-      - name: 📢 Upload testResults
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: testResults-${{ runner.os }}
-          path: ${{ runner.temp }}/_artifacts/testResults
-        continue-on-error: true
-      - name: 📢 Upload coverageResults
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverageResults-${{ runner.os }}
-          path: ${{ runner.temp }}/_artifacts/coverageResults
-        continue-on-error: true
-      - name: 📢 Upload symbols
-        uses: actions/upload-artifact@v4
-        with:
-          name: symbols-${{ runner.os }}
-          path: ${{ runner.temp }}/_artifacts/symbols
-        continue-on-error: true
-      - name: 📢 Upload rust
-        uses: actions/upload-artifact@v4
-        with:
-          name: rust-${{ runner.os }}
-          path: ${{ runner.temp }}/_artifacts/rust
-        if: always()
-      - name: 📢 Upload ios_framework
-        uses: actions/upload-artifact@v4
-        with:
-          name: ios_framework
-          path: ${{ runner.temp }}/_artifacts/ios_framework
-        if: startsWith(matrix.os, 'macos')
-      - name: 📢 Publish code coverage results to codecov.io
-        run: ./azure-pipelines/publish-CodeCov.ps1 -CodeCovToken "${{ secrets.CODECOV_TOKEN }}" -PathToCodeCoverage "${{ runner.temp }}/_artifacts/coverageResults" -Name "${{ runner.os }} Coverage Results" -Flags "${{ runner.os }}Host,${{ env.BUILDCONFIGURATION }}"
-        shell: pwsh
-        timeout-minutes: 3
-        continue-on-error: true
-        if: always()
+    - name: 🛠 dotnet build
+      run: |
+        dotnet build -t:build -p:Platform=x64 --no-restore -c ${{ env.BUILDCONFIGURATION }} -warnaserror /bl:"${{ runner.temp }}/_artifacts/build_logs/build_x64.binlog"
+        dotnet build -t:build -p:Platform=ARM64 --no-restore -c ${{ env.BUILDCONFIGURATION }} -warnaserror /bl:"${{ runner.temp }}/_artifacts/build_logs/build_arm64.binlog"
+    - name: 🧪 dotnet test
+      run: azure-pipelines/dotnet-test-cloud.ps1 -Configuration ${{ env.BUILDCONFIGURATION }} -Agent ${{ runner.os }}
+      shell: pwsh
+    - name: ⚙ Update pipeline variables based on build outputs
+      run: azure-pipelines/variables/_pipelines.ps1
+      shell: pwsh
+    - name: 📥 Collect artifacts
+      run: azure-pipelines/artifacts/_stage_all.ps1
+      shell: pwsh
+      if: always()
+    - name: 📢 Upload project.assets.json files
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: projectAssetsJson-${{ runner.os }}
+        path: ${{ runner.temp }}/_artifacts/projectAssetsJson
+      continue-on-error: true
+    - name: 📢 Upload variables
+      uses: actions/upload-artifact@v4
+      with:
+        name: variables-${{ runner.os }}
+        path: ${{ runner.temp }}/_artifacts/Variables
+      continue-on-error: true
+    - name: 📢 Upload build_logs
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: build_logs-${{ runner.os }}
+        path: ${{ runner.temp }}/_artifacts/build_logs
+      continue-on-error: true
+    - name: 📢 Upload test_logs
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: test_logs-${{ runner.os }}
+        path: ${{ runner.temp }}/_artifacts/test_logs
+      continue-on-error: true
+    - name: 📢 Upload testResults
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: testResults-${{ runner.os }}
+        path: ${{ runner.temp }}/_artifacts/testResults
+      continue-on-error: true
+    - name: 📢 Upload coverageResults
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverageResults-${{ runner.os }}
+        path: ${{ runner.temp }}/_artifacts/coverageResults
+      continue-on-error: true
+    - name: 📢 Upload symbols
+      uses: actions/upload-artifact@v4
+      with:
+        name: symbols-${{ runner.os }}
+        path: ${{ runner.temp }}/_artifacts/symbols
+      continue-on-error: true
+    - name: 📢 Upload rust
+      uses: actions/upload-artifact@v4
+      with:
+        name: rust-${{ runner.os }}
+        path: ${{ runner.temp }}/_artifacts/rust
+      if: always()
+    - name: 📢 Upload ios_framework
+      uses: actions/upload-artifact@v4
+      with:
+        name: ios_framework
+        path: ${{ runner.temp }}/_artifacts/ios_framework
+      if: startsWith(matrix.os, 'macos')
+    - name: 📢 Publish code coverage results to codecov.io
+      run: ./azure-pipelines/publish-CodeCov.ps1 -CodeCovToken "${{ secrets.CODECOV_TOKEN }}" -PathToCodeCoverage "${{ runner.temp }}/_artifacts/coverageResults" -Name "${{ runner.os }} Coverage Results" -Flags "${{ runner.os }}Host,${{ env.BUILDCONFIGURATION }}"
+      shell: pwsh
+      timeout-minutes: 3
+      continue-on-error: true
+      if: always()
 
   android:
     runs-on: ubuntu-20.04
@@ -177,104 +177,104 @@ jobs:
     - android
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
 
-      - name: ⚙ Install prerequisites
-        run: |
-          ./init.ps1 -UpgradePrerequisites
-          dotnet --info
+    - name: ⚙ Install prerequisites
+      run: |
+        ./init.ps1 -UpgradePrerequisites
+        dotnet --info
 
-          # Print mono version if it is present.
-          if (Get-Command mono -ErrorAction SilentlyContinue) {
-            mono --version
-          }
-        shell: pwsh
+        # Print mono version if it is present.
+        if (Get-Command mono -ErrorAction SilentlyContinue) {
+          mono --version
+        }
+      shell: pwsh
 
-      - uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-bundle-licenses
-        name: ⚙️ Install cargo-bundle-licenses
+    - uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-bundle-licenses
+      name: ⚙️ Install cargo-bundle-licenses
 
-      - name: 🪪 3rd party licenses
-        run: src/nerdbank-qrcodes/Generate-3rdPartyNotices.ps1
-        shell: pwsh
+    - name: 🪪 3rd party licenses
+      run: src/nerdbank-qrcodes/Generate-3rdPartyNotices.ps1
+      shell: pwsh
 
-      - name: 🔻 Download linux artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: rust-Linux
-          path: src/nerdbank-qrcodes/target
+    - name: 🔻 Download linux artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: rust-Linux
+        path: src/nerdbank-qrcodes/target
 
-      - name: 🔻 Download android artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: rust-android
-          path: src/nerdbank-qrcodes/target
+    - name: 🔻 Download android artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: rust-android
+        path: src/nerdbank-qrcodes/target
 
-      - name: 🔻 Download windows artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: rust-Windows
-          path: src/nerdbank-qrcodes/target
+    - name: 🔻 Download windows artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: rust-Windows
+        path: src/nerdbank-qrcodes/target
 
-      - name: 🔻 Download macOS artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: rust-macOS
-          path: src/nerdbank-qrcodes/target
+    - name: 🔻 Download macOS artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: rust-macOS
+        path: src/nerdbank-qrcodes/target
 
-      - name: 🔻 Download iOS framework
-        uses: actions/download-artifact@v4
-        with:
-          name: ios_framework
-          path: bin/release/nerdbank_qrcodes.xcframework
+    - name: 🔻 Download iOS framework
+      uses: actions/download-artifact@v4
+      with:
+        name: ios_framework
+        path: bin/release/nerdbank_qrcodes.xcframework
 
-      - name: 🛠 dotnet pack
-        run: dotnet pack --no-restore -c ${{ env.BUILDCONFIGURATION }} -warnaserror /bl:"${{ runner.temp }}/_artifacts/build_logs/build.binlog"
+    - name: 🛠 dotnet pack
+      run: dotnet pack --no-restore -c ${{ env.BUILDCONFIGURATION }} -warnaserror /bl:"${{ runner.temp }}/_artifacts/build_logs/build.binlog"
 
-      - name: 📥 Collect artifacts
-        run: azure-pipelines/artifacts/_stage_all.ps1
-        shell: pwsh
-        if: always()
+    - name: 📥 Collect artifacts
+      run: azure-pipelines/artifacts/_stage_all.ps1
+      shell: pwsh
+      if: always()
 
-      - name: 📢 Upload deployables
-        uses: actions/upload-artifact@v4
-        with:
-          name: deployables
-          path: ${{ runner.temp }}/_artifacts/deployables
-        if: always()
+    - name: 📢 Upload deployables
+      uses: actions/upload-artifact@v4
+      with:
+        name: deployables
+        path: ${{ runner.temp }}/_artifacts/deployables
+      if: always()
 
   ship:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: pack
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 1
 
-      - name: 🔻 Download deployables artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: deployables
-          path: ${{ runner.temp }}/deployables
+    - name: 🔻 Download deployables artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: deployables
+        path: ${{ runner.temp }}/deployables
 
-      - name: 🔏 Code sign
-        run: >
-          dotnet tool install --tool-path obj SignClient
+    - name: 🔏 Code sign
+      run: >
+        dotnet tool install --tool-path obj SignClient
 
-          obj/SignClient sign
-          --baseDirectory '${{ runner.temp }}/deployables'
-          --input '**/*'
-          --config '${{ github.workspace }}/azure-pipelines/SignClient.json'
-          --filelist '${{ github.workspace }}/azure-pipelines/signfiles.txt'
-          --user '${{ secrets.CODESIGN_USERNAME }}'
-          --secret '${{ secrets.CODESIGN_SECRET }}'
-          --name 'Nerdbank.Streams'
-          --descriptionUrl 'https://github.com/nerdcash/Nerdbank.QRCodes'
-        shell: pwsh
+        obj/SignClient sign
+        --baseDirectory '${{ runner.temp }}/deployables'
+        --input '**/*'
+        --config '${{ github.workspace }}/azure-pipelines/SignClient.json'
+        --filelist '${{ github.workspace }}/azure-pipelines/signfiles.txt'
+        --user '${{ secrets.CODESIGN_USERNAME }}'
+        --secret '${{ secrets.CODESIGN_SECRET }}'
+        --name 'Nerdbank.Streams'
+        --descriptionUrl 'https://github.com/nerdcash/Nerdbank.QRCodes'
+      shell: pwsh
 
-      - name: 🚀 Push NuGet packages
-        run: dotnet nuget push ${{ runner.temp }}/deployables/*.nupkg --source https://api.nuget.org/v3/index.json -k '${{ secrets.NUGET_API_KEY }}'
+    - name: 🚀 Push NuGet packages
+      run: dotnet nuget push ${{ runner.temp }}/deployables/*.nupkg --source https://api.nuget.org/v3/index.json -k '${{ secrets.NUGET_API_KEY }}'

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,17 +7,17 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageVersion Include="QRCoder" Version="1.6.0" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageVersion Include="System.Drawing.Common" Version="8.0.7" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
-    <PackageVersion Include="xunit" Version="2.9.0" />
+    <PackageVersion Include="xunit" Version="2.9.1" />
   </ItemGroup>
   <ItemGroup>
     <GlobalPackageReference Include="CSharpIsNullAnalyzer" Version="0.1.593" />
     <GlobalPackageReference Include="DotNetAnalyzers.DocumentationAnalyzers" Version="1.0.0-beta.59" />
-    <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.6.139" />
+    <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.6.143" />
     <GlobalPackageReference Include="Nullable" Version="1.3.1" />
     <GlobalPackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556" />
   </ItemGroup>

--- a/azure-pipelines/publish-codecoverage.yml
+++ b/azure-pipelines/publish-codecoverage.yml
@@ -17,9 +17,8 @@ steps:
   condition: and(succeeded(), ${{ parameters.includeMacOS }})
 - powershell: azure-pipelines/Merge-CodeCoverage.ps1 -Path '$(Pipeline.Workspace)' -OutputFile coveragereport/merged.cobertura.xml -Format Cobertura -Verbose
   displayName: ⚙ Merge coverage
-- task: PublishCodeCoverageResults@1
+- task: PublishCodeCoverageResults@2
   displayName: 📢 Publish code coverage results to Azure DevOps
   inputs:
-    codeCoverageTool: cobertura
     summaryFileLocation: coveragereport/merged.cobertura.xml
     failIfCoverageEmpty: true

--- a/azurepipelines-coverage.yml
+++ b/azurepipelines-coverage.yml
@@ -1,0 +1,6 @@
+# https://learn.microsoft.com/azure/devops/pipelines/test/codecoverage-for-pullrequests?view=azure-devops
+coverage:
+  status:
+    comments: on    # add comment to PRs reporting diff in coverage of modified files
+    diff:           # diff coverage is code coverage only for the lines changed in a pull request.
+      target: 70%   # set this to a desired %. Default is 70%

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.300",
+    "version": "8.0.400",
     "rollForward": "patch",
     "allowPrerelease": false
   }


### PR DESCRIPTION
- Update PublishCodeCoverageResults task to v2
- Fix github actions warnings
- Skip codecov publishing without token
- Enable CA2016: forward the CancellationToken
- Bump powershell from 7.4.3 to 7.4.4 (#277)
- Bump Nerdbank.GitVersioning from 3.6.139 to 3.6.141 (#280)
- Bump nbgv from 3.6.139 to 3.6.141 (#279)
- Bump dotnet-coverage from 17.11.3 to 17.11.5 (#278)
- Bump .NET SDK to 8.0.400
- Post code coverage diff comments for AzDO PRs
- Bump Microsoft.NET.Test.Sdk to 17.11
- Bump powershell from 7.4.4 to 7.4.5 (#282)
- Bump Nerdbank.GitVersioning from 3.6.141 to 3.6.143 (#283)
- Bump nbgv from 3.6.141 to 3.6.143 (#284)
- Bump dotnet-coverage from 17.11.5 to 17.12.2 (#285)
- Bump dotnet-coverage from 17.12.2 to 17.12.3 (#288)
- Bump Microsoft.NET.Test.Sdk from 17.11.0 to 17.11.1 (#287)
- Bump dotnet-coverage from 17.12.3 to 17.12.4 (#289)
- Bump xunit from 2.9.0 to 2.9.1 (#290)
- Normalize list indentation in build.yml
